### PR TITLE
[codex] Run Go tests with the Datastore emulator

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -1,0 +1,58 @@
+name: Test
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+
+permissions:
+  contents: read
+
+env:
+  DATASTORE_EMULATOR_HOST: 127.0.0.1:8080
+  DATASTORE_PROJECT_ID: dutil-test
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@9f698171ed81b15d1823a05fc7211befd50c8ae0 # v6.0.3
+
+      - name: Set up Go
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
+        with:
+          go-version-file: go.mod
+          cache: true
+
+      - name: Set up Java
+        uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5.2.0
+        with:
+          distribution: temurin
+          java-version: "21"
+
+      - name: Set up Google Cloud CLI
+        uses: google-github-actions/setup-gcloud@aa5489c8933f4cc7a4f7d45035b3b1440c9c10db # v3.0.1
+        with:
+          install_components: cloud-firestore-emulator
+
+      - name: Start Datastore emulator
+        run: |
+          gcloud emulators firestore start \
+            --database-mode=datastore-mode \
+            --host-port="${DATASTORE_EMULATOR_HOST}" \
+            > "${RUNNER_TEMP}/datastore-emulator.log" 2>&1 &
+
+          for attempt in {1..30}; do
+            if (echo > /dev/tcp/127.0.0.1/8080) 2>/dev/null; then
+              exit 0
+            fi
+            sleep 1
+          done
+
+          cat "${RUNNER_TEMP}/datastore-emulator.log"
+          exit 1
+
+      - name: Run tests
+        run: go test -cover ./...


### PR DESCRIPTION
## Summary

- add a GitHub Actions workflow for Go tests on pull requests and pushes to `main`
- install Java 21 and the Cloud Firestore emulator component
- start the emulator in Datastore mode and expose it through `DATASTORE_EMULATOR_HOST`
- run the full Go test suite with coverage

## Why

The repository did not have a workflow that continuously ran its Go tests. This also prepares CI for future tests that use the Datastore emulator without requiring credentials or a live Google Cloud project.

## Validation

- `go test -cover ./...`
- parsed `.github/workflows/test.yaml` with Ruby YAML
- `git diff --check`