### PR TITLE
[codex] Preserve keys on embedded entities

### DIFF
--- a/README.md
+++ b/README.md
@@ -333,7 +333,10 @@ type Value = {
     value: string // RFC3339 format
 } | {
     type: "entity"
-    value: []Property
+    value: Property[] | {
+        key: Key
+        properties: Property[]
+    }
 } | {
     type: "float"
     value: number // float64

--- a/internal/datastore/value.go
+++ b/internal/datastore/value.go
@@ -1,6 +1,7 @@
 package datastore
 
 import (
+	"bytes"
 	"encoding/json"
 	"fmt"
 	"time"
@@ -12,6 +13,11 @@ import (
 type Value struct {
 	Type  Type `json:"type"`
 	Value any  `json:"value"`
+}
+
+type EmbeddedEntity struct {
+	Key        *Key       `json:"key,omitempty"`
+	Properties []Property `json:"properties"`
 }
 
 func (v *Value) fromDatastoreProtoValue(src *datastorepb.Value) {
@@ -45,7 +51,14 @@ func (v *Value) fromDatastoreValue(src any) {
 		for i, v := range src.Properties {
 			dest[i].fromDatastoreProperty(v)
 		}
-		v.Value = dest
+		if src.Key == nil {
+			v.Value = dest
+		} else {
+			v.Value = EmbeddedEntity{
+				Key:        FromDatastoreKey(src.Key),
+				Properties: dest,
+			}
+		}
 
 	case GeoPointType:
 		src := src.(datastore.GeoPoint)
@@ -71,9 +84,21 @@ func (v *Value) toDatastoreValue() any {
 		return dest
 
 	case EntityType:
-		src := v.Value.([]Property)
-		dest := &datastore.Entity{Properties: make([]datastore.Property, len(src))}
-		for i, v := range src {
+		var key *datastore.Key
+		var properties []Property
+		switch src := v.Value.(type) {
+		case []Property:
+			properties = src
+		case EmbeddedEntity:
+			properties = src.Properties
+			if src.Key != nil {
+				key = src.Key.ToDatastore()
+			}
+		default:
+			panic(fmt.Sprintf("unexpected entity value type: %T", v.Value))
+		}
+		dest := &datastore.Entity{Key: key, Properties: make([]datastore.Property, len(properties))}
+		for i, v := range properties {
 			dest.Properties[i] = v.toDatastoreProperty()
 		}
 		return dest
@@ -127,11 +152,23 @@ func (v *Value) UnmarshalJSON(b []byte) error {
 		}
 		v.Value = value
 	case EntityType:
-		value, err := unmarshalJSON[[]Property](box.Value)
-		if err != nil {
-			return err
+		valueJSON := bytes.TrimSpace(box.Value)
+		switch {
+		case bytes.HasPrefix(valueJSON, []byte("[")):
+			value, err := unmarshalJSON[[]Property](box.Value)
+			if err != nil {
+				return err
+			}
+			v.Value = value
+		case bytes.HasPrefix(valueJSON, []byte("{")):
+			value, err := unmarshalJSON[EmbeddedEntity](box.Value)
+			if err != nil {
+				return err
+			}
+			v.Value = value
+		default:
+			return fmt.Errorf("entity value must be an array or object")
 		}
-		v.Value = value
 	case FloatType:
 		value, err := unmarshalJSON[float64](box.Value)
 		if err != nil {

--- a/internal/datastore/value_test.go
+++ b/internal/datastore/value_test.go
@@ -1,0 +1,90 @@
+package datastore
+
+import (
+	"encoding/json"
+	"reflect"
+	"testing"
+
+	clouddatastore "cloud.google.com/go/datastore"
+)
+
+func TestValueEntityRoundTripPreservesKey(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		key  *clouddatastore.Key
+	}{
+		{name: "without key"},
+		{name: "with complete key", key: clouddatastore.NameKey("Embedded", "example", nil)},
+		{name: "with incomplete key", key: clouddatastore.IncompleteKey("Embedded", nil)},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			src := &clouddatastore.Entity{
+				Key: tt.key,
+				Properties: []clouddatastore.Property{
+					{Name: "name", Value: "example"},
+				},
+			}
+
+			var value Value
+			value.fromDatastoreValue(src)
+
+			got := value.toDatastoreValue().(*clouddatastore.Entity)
+			if tt.key == nil {
+				if got.Key != nil {
+					t.Fatalf("unexpected key after round trip: %v", got.Key)
+				}
+				return
+			}
+			if got.Key == nil {
+				t.Fatal("entity key was lost during round trip")
+			}
+			if !got.Key.Equal(tt.key) {
+				t.Fatalf("entity key changed during round trip: got %v, want %v", got.Key, tt.key)
+			}
+		})
+	}
+}
+
+func TestValueEntityJSONCompatibility(t *testing.T) {
+	t.Parallel()
+
+	legacyJSON := []byte(`{"type":"entity","value":[{"type":"string","value":"example","name":"name"}]}`)
+	var legacy Value
+	if err := json.Unmarshal(legacyJSON, &legacy); err != nil {
+		t.Fatalf("failed to unmarshal legacy entity value: %v", err)
+	}
+	if _, ok := legacy.Value.([]Property); !ok {
+		t.Fatalf("legacy entity value has unexpected type: %T", legacy.Value)
+	}
+	gotLegacy, err := json.Marshal(&legacy)
+	if err != nil {
+		t.Fatalf("failed to marshal legacy entity value: %v", err)
+	}
+	if !reflect.DeepEqual(gotLegacy, legacyJSON) {
+		t.Fatalf("keyless entity JSON changed: got %s, want %s", gotLegacy, legacyJSON)
+	}
+
+	keyedJSON := []byte(`{"type":"entity","value":{"key":{"kind":"Embedded","name":"example"},"properties":[{"type":"string","value":"example","name":"name"}]}}`)
+	var keyed Value
+	if err := json.Unmarshal(keyedJSON, &keyed); err != nil {
+		t.Fatalf("failed to unmarshal keyed entity value: %v", err)
+	}
+	entity := keyed.toDatastoreValue().(*clouddatastore.Entity)
+	wantKey := clouddatastore.NameKey("Embedded", "example", nil)
+	if entity.Key == nil || !entity.Key.Equal(wantKey) {
+		t.Fatalf("unexpected embedded entity key: got %v, want %v", entity.Key, wantKey)
+	}
+	gotKeyed, err := json.Marshal(&keyed)
+	if err != nil {
+		t.Fatalf("failed to marshal keyed entity value: %v", err)
+	}
+	if !reflect.DeepEqual(gotKeyed, keyedJSON) {
+		t.Fatalf("keyed entity JSON changed: got %s, want %s", gotKeyed, keyedJSON)
+	}
+}


### PR DESCRIPTION
## Summary

- preserve complete and incomplete keys on embedded Datastore entities
- keep the existing array JSON representation for keyless embedded entities
- add an object JSON representation for keyed embedded entities
- document both representations and add round-trip compatibility tests

## Root cause

The internal entity-value conversion copied only `datastore.Entity.Properties`, discarding `datastore.Entity.Key`. The reverse conversion therefore always produced a keyless embedded entity.

## Impact

Query and lookup output can now retain embedded-entity keys, and insert, update, and upsert input can restore them without changing existing keyless JSON output.

## Validation

- `go test ./internal/datastore -count=1`
- `git diff --check HEAD`

`go test ./...` still has pre-existing failures in `internal/command/convert` caused by protobuf text-format whitespace differences.

Closes #2