### PR TITLE
[codex] Stabilize proto key conversion tests

### DIFF
--- a/internal/command/convert/key_test.go
+++ b/internal/command/convert/key_test.go
@@ -1,12 +1,14 @@
 package convert_test
 
 import (
+	"net/url"
 	"strings"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/karupanerura/dutil/internal/command"
 	"github.com/karupanerura/dutil/internal/command/convert"
+	"github.com/karupanerura/dutil/internal/datastore"
 )
 
 func TestKeyCommand_Run(t *testing.T) {
@@ -33,9 +35,7 @@ func TestKeyCommand_Run(t *testing.T) {
 						t.Fatal(err)
 					}
 
-					if df := cmp.Diff(expected, strings.TrimSuffix(stdout.String(), "\n")); df != "" {
-						t.Errorf("expected convert: %s -> %s: %s", from, to, df)
-					}
+					assertKeyOutput(t, to, expected, stdout.String())
 				})
 			}
 		})
@@ -56,9 +56,7 @@ func TestKeyCommand_Run(t *testing.T) {
 						t.Fatal(err)
 					}
 
-					if df := cmp.Diff(expected, strings.TrimSuffix(stdout.String(), "\n")); df != "" {
-						t.Errorf("expected convert key: %s -> %s: %s", from, to, df)
-					}
+					assertKeyOutput(t, to, expected, stdout.String())
 				})
 			}
 		})
@@ -86,14 +84,6 @@ func getExpected(format string) string {
 			"Eg8KA0ZvbxoIRm9vTmFtZTISDwoDQmF6GghCYXpOYW1lMg",
 		}, "\n")
 	case "proto":
-		// workaround for unstable proto encoder when debugging or cover
-		if testing.CoverMode() != "" {
-			return strings.Join([]string{
-				"path%3A++%7B%0A++kind%3A++%22Foo%22%0A++name%3A++%22FooName1%22%0A%7D%0A",
-				"path%3A++%7B%0A++kind%3A++%22Bar%22%0A++id%3A++1%0A%7D%0A",
-				"path%3A++%7B%0A++kind%3A++%22Foo%22%0A++name%3A++%22FooName2%22%0A%7D%0Apath%3A++%7B%0A++kind%3A++%22Baz%22%0A++name%3A++%22BazName2%22%0A%7D%0A",
-			}, "\n")
-		}
 		return strings.Join([]string{
 			"path%3A+%7B%0A++kind%3A+%22Foo%22%0A++name%3A+%22FooName1%22%0A%7D%0A",
 			"path%3A+%7B%0A++kind%3A+%22Bar%22%0A++id%3A+1%0A%7D%0A",
@@ -101,5 +91,54 @@ func getExpected(format string) string {
 		}, "\n")
 	default:
 		panic("unknown format: " + format)
+	}
+}
+
+func assertKeyOutput(t *testing.T, format, expected, actual string) {
+	t.Helper()
+
+	if !strings.HasSuffix(actual, "\n") {
+		t.Fatal("key output does not end with a newline")
+	}
+	actual = strings.TrimSuffix(actual, "\n")
+	if format != "proto" {
+		if df := cmp.Diff(expected, actual); df != "" {
+			t.Errorf("unexpected key output (-want +got):\n%s", df)
+		}
+		return
+	}
+
+	expectedLines := strings.Split(expected, "\n")
+	actualLines := strings.Split(actual, "\n")
+	if len(actualLines) != len(expectedLines) {
+		t.Fatalf("unexpected number of proto keys: got %d, want %d", len(actualLines), len(expectedLines))
+	}
+
+	for i := range expectedLines {
+		assertProtoKey(t, i, expectedLines[i], actualLines[i])
+	}
+}
+
+func assertProtoKey(t *testing.T, line int, expected, actual string) {
+	t.Helper()
+
+	decoded, err := url.QueryUnescape(actual)
+	if err != nil {
+		t.Fatalf("proto key line %d is not valid query encoding: %v", line+1, err)
+	}
+	if reencoded := url.QueryEscape(decoded); reencoded != actual {
+		t.Errorf("proto key line %d is not canonically query encoded: got %q, want %q", line+1, actual, reencoded)
+	}
+
+	want, err := datastore.ParseEncodedProtoKey(expected)
+	if err != nil {
+		t.Fatalf("invalid expected proto key on line %d: %v", line+1, err)
+	}
+	got, err := datastore.ParseEncodedProtoKey(actual)
+	if err != nil {
+		t.Fatalf("invalid proto key output on line %d: %v", line+1, err)
+	}
+	if df := cmp.Diff(want, got); df != "" {
+		t.Errorf("unexpected proto key on line %d (-want +got):\n%s", line+1, df)
 	}
 }


### PR DESCRIPTION
## Summary

- compare proto key output by decoded key semantics instead of unstable TextProto whitespace
- keep strict checks for canonical query encoding, output line count, and trailing newlines
- remove the coverage-specific expected output workaround

## Root cause

`prototext.Format` intentionally varies whitespace across different Go binaries. The test selected one of two exact strings based on `testing.CoverMode()`, but the protobuf formatting seed depends on the complete binary rather than coverage alone.

## Impact

The conversion behavior and CLI output remain unchanged. Tests now verify the intended Java SDK compatibility contract without depending on insignificant TextProto spacing.

## Validation

- `go test -count=1 ./...`
- `go test -cover -count=1 ./...`
- `go test -gcflags=all='-N -l' -count=1 ./internal/command/convert`

Closes #12