### PR TITLE
fix: return errors instead of panicking on invalid filter input

### DIFF
--- a/internal/parser/filter.go
+++ b/internal/parser/filter.go
@@ -74,11 +74,11 @@ func (p *FilterParser) convertCondition(c gqlparser.Condition) (*datastore.Key, 
 	case *gqlparser.ForwardComparatorCondition:
 		if c.Comparator == gqlparser.HasAncestorForwardComparator {
 			if c.Property.String() != "__key__" {
-				panic("HAS ANCESTOR is only valid for __key__")
+				return nil, nil, fmt.Errorf("HAS ANCESTOR is only valid for __key__")
 			}
 			key, ok := c.Value.(*gqlparser.Key)
 			if !ok {
-				panic("HAS ANCESTOR value must be a key")
+				return nil, nil, fmt.Errorf("HAS ANCESTOR value must be a key")
 			}
 			return p.convertKey(key), nil, nil
 		}
@@ -98,9 +98,13 @@ func (p *FilterParser) convertCondition(c gqlparser.Condition) (*datastore.Key, 
 			}
 			value = keys
 		}
+		operator, err := convertForwardComparator(c.Comparator)
+		if err != nil {
+			return nil, nil, err
+		}
 		return nil, datastore.PropertyFilter{
 			FieldName: c.Property.String(),
-			Operator:  convertForwardComparator(c.Comparator),
+			Operator:  operator,
 			Value:     value,
 		}, nil
 
@@ -169,18 +173,18 @@ func (p *FilterParser) convertCondition(c gqlparser.Condition) (*datastore.Key, 
 			Value:     value,
 		}, nil
 	default:
-		panic(fmt.Sprintf("unknown condition: %T", c))
+		return nil, nil, fmt.Errorf("unknown condition: %T", c)
 	}
 }
 
-func convertForwardComparator(c gqlparser.ForwardComparator) string {
+func convertForwardComparator(c gqlparser.ForwardComparator) (string, error) {
 	switch c {
 	case gqlparser.InForwardComparator:
-		return "in"
+		return "in", nil
 	case gqlparser.NotInForwardComparator:
-		return "not-in"
+		return "not-in", nil
 	default:
-		panic(fmt.Sprintf("unknown forward comparator: %s", c))
+		return "", fmt.Errorf("unknown forward comparator: %s", c)
 	}
 }
 

--- a/internal/parser/filter_test.go
+++ b/internal/parser/filter_test.go
@@ -85,3 +85,32 @@ func TestFilterParserParseFilterKeyLiterals(t *testing.T) {
 		})
 	}
 }
+
+func TestFilterParserParseFilterInvalid(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name   string
+		filter string
+	}{
+		{
+			name:   "HAS ANCESTOR on non-key property",
+			filter: `name HAS ANCESTOR KEY(ParentKind, "parent")`,
+		},
+		{
+			name:   "HAS ANCESTOR with non-key value",
+			filter: `__key__ HAS ANCESTOR "parent"`,
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			if _, _, err := (&FilterParser{}).ParseFilter(tt.filter); err == nil {
+				t.Fatalf("ParseFilter(%q) error = nil, want error", tt.filter)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Closes #6.

The filter parser panicked on a few user-reachable conditions: HAS ANCESTOR on a non-`__key__` property, HAS ANCESTOR with a non-key value, and unknown condition/comparator combinations. Since `convertCondition` already returns an error, these now return errors so malformed filters surface a message instead of crashing. Internal invariants are unaffected; this only touches the user-facing parser paths. Added regression coverage for the two HAS ANCESTOR cases.